### PR TITLE
Full Ruby 1.9.2 compatibility

### DIFF
--- a/ext/tokyo_tyrant_bdb.c
+++ b/ext/tokyo_tyrant_bdb.c
@@ -81,7 +81,7 @@ static VALUE cBDB_each(VALUE vself){
   TCLIST *result;
   TCRDB *db = mTokyoTyrant_getdb(vself);
 
-  if(rb_block_given_p() != Qtrue) rb_raise(rb_eArgError, "no block given");
+  if(!rb_block_given_p()) rb_raise(rb_eArgError, "no block given");
 
   tcrdbiterinit(db);
   tcrdbmisc(db, "iterinit", RDBMONOULOG, tclistnew());

--- a/ext/tokyo_tyrant_db.c
+++ b/ext/tokyo_tyrant_db.c
@@ -138,7 +138,7 @@ static VALUE cDB_vsiz(VALUE vself, VALUE vkey){
 static VALUE cDB_fetch(int argc, VALUE *argv, VALUE vself){
   VALUE vkey, vrv, vforce;
   rb_scan_args(argc, argv, "11", &vkey, &vforce);
-  if(rb_block_given_p() != Qtrue) rb_raise(rb_eArgError, "no block given");
+  if(!rb_block_given_p()) rb_raise(rb_eArgError, "no block given");
   if(vforce == Qnil) vforce = Qfalse;
 
   if(vforce != Qfalse || (vrv = cDB_get(vself, vkey)) == Qnil){
@@ -150,7 +150,7 @@ static VALUE cDB_fetch(int argc, VALUE *argv, VALUE vself){
 
 static VALUE cDB_each(VALUE vself){
   VALUE vrv;
-  if(rb_block_given_p() != Qtrue) rb_raise(rb_eArgError, "no block given");
+  if(!rb_block_given_p()) rb_raise(rb_eArgError, "no block given");
   TCRDB *db = mTokyoTyrant_getdb(vself);
   vrv = Qnil;
   tcrdbiterinit(db);
@@ -169,7 +169,7 @@ static VALUE cDB_each(VALUE vself){
 
 static VALUE cDB_each_value(VALUE vself){
   VALUE vrv;
-  if(rb_block_given_p() != Qtrue) rb_raise(rb_eArgError, "no block given");
+  if(!rb_block_given_p()) rb_raise(rb_eArgError, "no block given");
   TCRDB *db = mTokyoTyrant_getdb(vself);
   vrv = Qnil;
   tcrdbiterinit(db);

--- a/ext/tokyo_tyrant_module.c
+++ b/ext/tokyo_tyrant_module.c
@@ -432,7 +432,7 @@ static VALUE mTokyoTyrant_ext(VALUE vself, VALUE vext, VALUE vkey, VALUE vval){
 static VALUE mTokyoTyrant_each_key(VALUE vself){
   VALUE vrv = Qnil;
   char *kbuf;
-  if(rb_block_given_p() != Qtrue) rb_raise(rb_eArgError, "no block given");
+  if(!rb_block_given_p()) rb_raise(rb_eArgError, "no block given");
   TCRDB *db = mTokyoTyrant_getdb(vself);
 
   tcrdbiterinit(db);

--- a/ext/tokyo_tyrant_table.c
+++ b/ext/tokyo_tyrant_table.c
@@ -171,7 +171,7 @@ static VALUE cTable_genuid(VALUE vself){
 static VALUE cTable_fetch(int argc, VALUE *argv, VALUE vself){
   VALUE vkey, vrv, vforce;
   rb_scan_args(argc, argv, "11", &vkey, &vforce);
-  if(rb_block_given_p() != Qtrue) rb_raise(rb_eArgError, "no block given");
+  if(!rb_block_given_p()) rb_raise(rb_eArgError, "no block given");
   if(vforce == Qnil) vforce = Qfalse;
   vkey = StringValueEx(vkey);
 
@@ -187,7 +187,7 @@ static VALUE cTable_each(VALUE vself){
   VALUE vrv = Qnil;
   char *kbuf;
   int ksiz;
-  if(rb_block_given_p() != Qtrue) rb_raise(rb_eArgError, "no block given");
+  if(!rb_block_given_p()) rb_raise(rb_eArgError, "no block given");
   TCRDB *db = mTokyoTyrant_getdb(vself);
 
   tcrdbiterinit(db);
@@ -205,7 +205,7 @@ static VALUE cTable_each_value(VALUE vself){
   VALUE vrv = Qnil;
   char *kbuf;
   int ksiz;
-  if(rb_block_given_p() != Qtrue) rb_raise(rb_eArgError, "no block given");
+  if(!rb_block_given_p()) rb_raise(rb_eArgError, "no block given");
   TCRDB *db = mTokyoTyrant_getdb(vself);
 
   tcrdbiterinit(db);


### PR DESCRIPTION
Methods "each", "fetch" etc. were throwing a "no block given" error when using Ruby 1.9.2.
